### PR TITLE
allow most sentence punctuation to be adjacent to 'gender roll'

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -94,7 +94,7 @@ export const ENABLED_ROLLS = [BASE, GQ, TF, TM, NO_CAKE, YES_ROBOTS, YES_ROBOTS_
 
 function triggerRegexp(trigger) {
   // We can't use \b unfortunately, because + and - don't count as word characters.
-  return new RegExp(`(^|\\s)${_.escapeRegExp(trigger)}($|\\s)`, 'i');
+  return new RegExp(`(^|[^\\w\\-+])${_.escapeRegExp(trigger)}($|[^\\w\\-+])`, 'i');
 }
 
 export function determineRolls(text) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -93,7 +93,14 @@ export const ALL_ROLLS = {BASE, GQ, TF, TM, NO_CAKE, YES_ROBOTS, YES_ROBOTS_TF, 
 export const ENABLED_ROLLS = [BASE, GQ, TF, TM, NO_CAKE, YES_ROBOTS, YES_ROBOTS_TF, NO_LEATHER, NO_ANIMALS];
 
 function triggerRegexp(trigger) {
-  // We can't use \b unfortunately, because + and - don't count as word characters.
+  // This regex matches the 'trigger' as a discrete word. For example,
+  // "fenby roll" shouldn't be recognized as "enby roll" even though it
+  // contains the latter string. "-cake" should be recognized as a discrete
+  // word. We can't use \b for this unfortunately, because + and - don't
+  // count as word characters to \b.  Instead, in this regexp, we match the
+  // character immediately before 'trigger' to be any non-word character,
+  // or to be the beginning of the string (counting + and - as word
+  // characters). Likewise for the character after the end of the word.
   return new RegExp(`(^|[^\\w\\-+])${_.escapeRegExp(trigger)}($|[^\\w\\-+])`, 'i');
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -58,11 +58,14 @@ describe('determineRolls', function () {
       [[ALL_ROLLS.BASE, ALL_ROLLS.GQ, ALL_ROLLS.TF], [ALL_ROLLS.YES_ROBOTS, ALL_ROLLS.YES_ROBOTS_TF]]);
   });
   it('should only match at word boundaries', function () {
-    // We've had two issues with this.
+    // We've had a few issues with this.
     // 1. 'agender roll' is not yet implemented, but 'gender roll' is.
     // A user types 'agender roll' and 'gender roll' matches, when it shouldn't.
     // 2. 'fenby roll' and 'enby roll' are both implemented. 'fenby roll' matches
     // both core roll types, and is thus ignored.
+    // 3. 'gender roll, please' needs to notice that ',' is not part of
+    // the 'roll' word. 'gender roll -cake' needs to notice that
+    // '-' is part of the 'cake' word. 'super-cake' is not '-cake'.
     // check assumptions
     expect(coreTriggers, 'not to contain', 'agender roll');
     expect(coreTriggers, 'to contain', 'gender roll');
@@ -71,6 +74,12 @@ describe('determineRolls', function () {
 
     expect(determineRolls('agender roll'), 'to be null');
     expect(determineRolls('fenby roll'), 'not to be null');
+    expect(determineRolls('gender roll!'), 'not to be null');
+    expect(determineRolls('+gender roll'), 'to be null');
+    expect(determineRolls('gender roll -cake +robot'), 'not to be null');
+    expect(determineRolls('gender roll -cake +robot')[1], 'to have length', 2);
+    expect(determineRolls('gender roll super-cake'), 'not to be null');
+    expect(determineRolls('gender roll super-cake')[1], 'to have length', 0);
   });
 });
 


### PR DESCRIPTION
This allows `I'd like a gender roll, please!` to work.  Or `genderqueer roll! +robots -cake`